### PR TITLE
Implement process_image_node to load and validate images

### DIFF
--- a/src/shelf_genius/nodes/process_image_node.py
+++ b/src/shelf_genius/nodes/process_image_node.py
@@ -33,7 +33,7 @@ def process_image_node(state: AgentState) -> AgentState:
 
         with Image.open(image_path) as img:
             # Placeholder for actual image processing logic
-            logger.info(f"Image {image_path} loaded successfully.")
+            logger.info(f"Image {image_path} loaded successfully. {img.size}")
 
         state["current_step"] = "process_image_node"
 

--- a/src/shelf_genius/nodes/process_image_node.py
+++ b/src/shelf_genius/nodes/process_image_node.py
@@ -1,19 +1,40 @@
 from typing import TypeVar
 
 from loguru import logger
+from PIL import Image
 
 from shelf_genius.models.shelf_genius_state import ShelfGeniusState
 
 AgentState = TypeVar("AgentState", bound=ShelfGeniusState)
 
 
+def validate_image_format(image_path: str) -> bool:
+    valid_formats = ["JPEG", "PNG"]
+    try:
+        with Image.open(image_path) as img:
+            if img.format not in valid_formats:
+                return False
+    except Exception as e:
+        logger.error(f"Error validating image format: {str(e)}")
+        return False
+    return True
+
+
 def process_image_node(state: AgentState) -> AgentState:
     try:
-        # TODO: Implement actual image processing logic
-        # This is a placeholder that will be expanded with actual image processing
         logger.info("Processing bookshelf image...")
 
-        # Update state with processed information
+        image_path = state.get("image_path")
+        if not image_path:
+            raise ValueError("Image path is missing in the state.")
+
+        if not validate_image_format(image_path):
+            raise ValueError("Unsupported image format. Only jpg and png are supported.")
+
+        with Image.open(image_path) as img:
+            # Placeholder for actual image processing logic
+            logger.info(f"Image {image_path} loaded successfully.")
+
         state["current_step"] = "process_image_node"
 
         return state

--- a/tests/test_process_image_node.py
+++ b/tests/test_process_image_node.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+from PIL import Image
+from shelf_genius.nodes.process_image_node import process_image_node
+from shelf_genius.models.shelf_genius_state import ShelfGeniusState
+
+@pytest.fixture
+def valid_jpg_image(tmp_path):
+    img_path = tmp_path / "test.jpg"
+    img = Image.new("RGB", (100, 100), color="red")
+    img.save(img_path)
+    return img_path
+
+@pytest.fixture
+def valid_png_image(tmp_path):
+    img_path = tmp_path / "test.png"
+    img = Image.new("RGB", (100, 100), color="blue")
+    img.save(img_path)
+    return img_path
+
+@pytest.fixture
+def invalid_image(tmp_path):
+    img_path = tmp_path / "test.bmp"
+    img = Image.new("RGB", (100, 100), color="green")
+    img.save(img_path)
+    return img_path
+
+def test_process_valid_jpg_image(valid_jpg_image):
+    state = ShelfGeniusState(image_path=str(valid_jpg_image))
+    new_state = process_image_node(state)
+    assert "error" not in new_state
+
+def test_process_valid_png_image(valid_png_image):
+    state = ShelfGeniusState(image_path=str(valid_png_image))
+    new_state = process_image_node(state)
+    assert "error" not in new_state
+
+def test_process_invalid_image(invalid_image):
+    state = ShelfGeniusState(image_path=str(invalid_image))
+    new_state = process_image_node(state)
+    assert "error" in new_state
+    assert new_state["error"] == "Image processing failed: Unsupported image format. Only jpg and png are supported."

--- a/tests/test_process_image_node.py
+++ b/tests/test_process_image_node.py
@@ -1,8 +1,9 @@
-import os
 import pytest
 from PIL import Image
-from shelf_genius.nodes.process_image_node import process_image_node
+
 from shelf_genius.models.shelf_genius_state import ShelfGeniusState
+from shelf_genius.nodes.process_image_node import process_image_node
+
 
 @pytest.fixture
 def valid_jpg_image(tmp_path):
@@ -11,12 +12,14 @@ def valid_jpg_image(tmp_path):
     img.save(img_path)
     return img_path
 
+
 @pytest.fixture
 def valid_png_image(tmp_path):
     img_path = tmp_path / "test.png"
     img = Image.new("RGB", (100, 100), color="blue")
     img.save(img_path)
     return img_path
+
 
 @pytest.fixture
 def invalid_image(tmp_path):
@@ -25,15 +28,18 @@ def invalid_image(tmp_path):
     img.save(img_path)
     return img_path
 
+
 def test_process_valid_jpg_image(valid_jpg_image):
     state = ShelfGeniusState(image_path=str(valid_jpg_image))
     new_state = process_image_node(state)
     assert "error" not in new_state
 
+
 def test_process_valid_png_image(valid_png_image):
     state = ShelfGeniusState(image_path=str(valid_png_image))
     new_state = process_image_node(state)
     assert "error" not in new_state
+
 
 def test_process_invalid_image(invalid_image):
     state = ShelfGeniusState(image_path=str(invalid_image))


### PR DESCRIPTION
Implement the process_image_node.py to load and validate images in the image_path of the ShelfGeniusState.

* **Image Validation and Loading**
  - Import `Image` from `PIL` to handle image loading.
  - Add `validate_image_format` function to check if the image format is either jpg or png.
  - Implement logic in `process_image_node` to load and validate the image, raising errors for missing or unsupported image formats.

* **Testing**
  - Add `tests/test_process_image_node.py` to test loading and validating jpg and png images.
  - Write tests for handling unsupported image formats.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PatrickKalkman/shelf-genius/pull/1?shareId=25ab8517-9741-4f68-9a1d-86d63b064901).