### PR TITLE
Add image metadata extraction and base64 conversion

### DIFF
--- a/src/shelf_genius/models/shelf_genius_state.py
+++ b/src/shelf_genius/models/shelf_genius_state.py
@@ -5,6 +5,11 @@ class ShelfGeniusState(TypedDict, total=False):
     """State management for the Shelf Genius agent."""
 
     image_path: str
+    image_width: int
+    image_height: int
+    image_format: str
+    image_original_path: str
+    image_base64: str
     # Placeholder for state fields - to be expanded later
     conversation_history: List[Dict[str, Any]]
     current_step: str

--- a/src/shelf_genius/nodes/process_image_node.py
+++ b/src/shelf_genius/nodes/process_image_node.py
@@ -1,5 +1,6 @@
-from typing import TypeVar
 import base64
+import io
+from typing import TypeVar
 
 from loguru import logger
 from PIL import Image

--- a/src/shelf_genius/nodes/process_image_node.py
+++ b/src/shelf_genius/nodes/process_image_node.py
@@ -1,4 +1,5 @@
 from typing import TypeVar
+import base64
 
 from loguru import logger
 from PIL import Image
@@ -32,7 +33,18 @@ def process_image_node(state: AgentState) -> AgentState:
             raise ValueError("Unsupported image format. Only jpg and png are supported.")
 
         with Image.open(image_path) as img:
-            # Placeholder for actual image processing logic
+            # Extract image metadata and add to state
+            state["image_width"] = img.width
+            state["image_height"] = img.height
+            state["image_format"] = img.format
+            state["image_original_path"] = image_path
+
+            # Convert image to base64 and add to state
+            buffered = io.BytesIO()
+            img.save(buffered, format=img.format)
+            img_base64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
+            state["image_base64"] = img_base64
+
             logger.info(f"Image {image_path} loaded successfully. {img.size}")
 
         state["current_step"] = "process_image_node"

--- a/tests/test_process_image_node.py
+++ b/tests/test_process_image_node.py
@@ -33,12 +33,22 @@ def test_process_valid_jpg_image(valid_jpg_image):
     state = ShelfGeniusState(image_path=str(valid_jpg_image))
     new_state = process_image_node(state)
     assert "error" not in new_state
+    assert new_state["image_width"] == 100
+    assert new_state["image_height"] == 100
+    assert new_state["image_format"] == "JPEG"
+    assert new_state["image_original_path"] == str(valid_jpg_image)
+    assert "image_base64" in new_state
 
 
 def test_process_valid_png_image(valid_png_image):
     state = ShelfGeniusState(image_path=str(valid_png_image))
     new_state = process_image_node(state)
     assert "error" not in new_state
+    assert new_state["image_width"] == 100
+    assert new_state["image_height"] == 100
+    assert new_state["image_format"] == "PNG"
+    assert new_state["image_original_path"] == str(valid_png_image)
+    assert "image_base64" in new_state
 
 
 def test_process_invalid_image(invalid_image):


### PR DESCRIPTION
Add image metadata extraction and base64 conversion to state in `process_image_node` function.

* **State Management**: Add `image_width`, `image_height`, `image_format`, `image_original_path`, and `image_base64` fields to `ShelfGeniusState` in `src/shelf_genius/models/shelf_genius_state.py`.
* **Image Processing**: Extract image metadata (width, height, format, original_path) and add to state. Convert image to base64 and add to state in `src/shelf_genius/nodes/process_image_node.py`.
* **Testing**: Add tests to verify image metadata extraction and base64 conversion in `tests/test_process_image_node.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PatrickKalkman/shelf-genius/pull/2?shareId=31210eb1-3c62-4b81-a378-30422fc96664).