### PR TITLE
Add unit test for process image node

### DIFF
--- a/tests/test_process_image_node.py
+++ b/tests/test_process_image_node.py
@@ -56,3 +56,21 @@ def test_process_invalid_image(invalid_image):
     new_state = process_image_node(state)
     assert "error" in new_state
     assert new_state["error"] == "Image processing failed: Unsupported image format. Only jpg and png are supported."
+
+
+def test_process_image_node(valid_jpg_image):
+    state = ShelfGeniusState(image_path=str(valid_jpg_image))
+    new_state = process_image_node(state)
+    assert "error" not in new_state
+    assert new_state["image_width"] == 100
+    assert new_state["image_height"] == 100
+    assert new_state["image_format"] == "JPEG"
+    assert new_state["image_original_path"] == str(valid_jpg_image)
+    assert "image_base64" in new_state
+
+
+def test_process_image_node_invalid_image(invalid_image):
+    state = ShelfGeniusState(image_path=str(invalid_image))
+    new_state = process_image_node(state)
+    assert "error" in new_state
+    assert new_state["error"] == "Image processing failed: Unsupported image format. Only jpg and png are supported."


### PR DESCRIPTION
Add new unit tests for the `process_image_node` function.

* Add `test_process_image_node` to test the `process_image_node` function with a valid image.
* Add `test_process_image_node_invalid_image` to test the `process_image_node` function with an invalid image.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PatrickKalkman/shelf-genius/pull/5?shareId=30229286-a96e-4bee-a71f-6fb0e7ddf93e).