### PR TITLE
Improve book lookup node to use multiple APIs

### DIFF
--- a/src/shelf_genius/nodes/book_lookup_node.py
+++ b/src/shelf_genius/nodes/book_lookup_node.py
@@ -24,8 +24,28 @@ def get_book_metadata(title: str, author: str) -> dict:
         return {}
 
 
+def get_book_metadata_from_openlibrary(title: str, author: str) -> dict:
+    """Retrieve book metadata from Open Library API."""
+    try:
+        query = f"title={title}"
+        if author:
+            query += f"&author={author}"
+        response = requests.get(
+            "https://openlibrary.org/search.json",
+            params={"q": query},
+        )
+        response.raise_for_status()
+        docs = response.json().get("docs", [])
+        if docs:
+            return docs[0]
+        return {}
+    except Exception as e:
+        logger.error(f"Error fetching book metadata from Open Library: {str(e)}")
+        return {}
+
+
 def book_lookup_node(state: ShelfGeniusState) -> ShelfGeniusState:
-    """Retrieve book metadata from Google Books API."""
+    """Retrieve book metadata from Google Books API and Open Library API."""
     try:
         logger.info("Starting book look up node...")
         recognized_books = state.get("recognized_books", [])
@@ -38,9 +58,11 @@ def book_lookup_node(state: ShelfGeniusState) -> ShelfGeniusState:
                 logger.info(f"Looking up book: {title} by {author}")
             else:
                 logger.info(f"Looking up book: {title}")
-            metadata = get_book_metadata(title, author)
-            if metadata:
-                book_metadata.append(metadata)
+            metadata_google = get_book_metadata(title, author)
+            metadata_openlibrary = get_book_metadata_from_openlibrary(title, author)
+            merged_metadata = {**metadata_google, **metadata_openlibrary}
+            if merged_metadata:
+                book_metadata.append(merged_metadata)
 
         # Update state with processed information
         state["book_metadata"] = book_metadata

--- a/tests/test_book_lookup_node.py
+++ b/tests/test_book_lookup_node.py
@@ -1,0 +1,59 @@
+import pytest
+import requests
+from unittest.mock import patch
+
+from shelf_genius.nodes.book_lookup_node import get_book_metadata_from_openlibrary, book_lookup_node
+from shelf_genius.models.shelf_genius_state import ShelfGeniusState, BookInfo
+
+
+def test_get_book_metadata_from_openlibrary():
+    title = "The Great Gatsby"
+    author = "F. Scott Fitzgerald"
+    expected_metadata = {
+        "title": "The Great Gatsby",
+        "author_name": ["F. Scott Fitzgerald"],
+        "first_publish_year": 1925,
+    }
+
+    with patch("requests.get") as mock_get:
+        mock_response = mock_get.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"docs": [expected_metadata]}
+
+        metadata = get_book_metadata_from_openlibrary(title, author)
+        assert metadata == expected_metadata
+
+
+def test_book_lookup_node():
+    state = ShelfGeniusState(
+        recognized_books=[
+            BookInfo(title="The Great Gatsby", author="F. Scott Fitzgerald"),
+            BookInfo(title="1984", author="George Orwell"),
+        ]
+    )
+
+    google_metadata = {
+        "title": "The Great Gatsby",
+        "authors": ["F. Scott Fitzgerald"],
+        "publishedDate": "1925",
+    }
+
+    openlibrary_metadata = {
+        "title": "The Great Gatsby",
+        "author_name": ["F. Scott Fitzgerald"],
+        "first_publish_year": 1925,
+    }
+
+    with patch("shelf_genius.nodes.book_lookup_node.get_book_metadata") as mock_google, \
+         patch("shelf_genius.nodes.book_lookup_node.get_book_metadata_from_openlibrary") as mock_openlibrary:
+        mock_google.return_value = google_metadata
+        mock_openlibrary.return_value = openlibrary_metadata
+
+        new_state = book_lookup_node(state)
+
+        assert "error" not in new_state
+        assert len(new_state["book_metadata"]) == 2
+        assert new_state["book_metadata"][0]["title"] == "The Great Gatsby"
+        assert new_state["book_metadata"][0]["authors"] == ["F. Scott Fitzgerald"]
+        assert new_state["book_metadata"][0]["first_publish_year"] == 1925
+        assert new_state["book_metadata"][1]["title"] == "1984"


### PR DESCRIPTION
Add functionality to fetch book metadata from Open Library API and merge it with Google Books API metadata.

* **src/shelf_genius/nodes/book_lookup_node.py**
  - Add `get_book_metadata_from_openlibrary` function to fetch book metadata from Open Library API.
  - Modify `book_lookup_node` function to use both Google Books API and Open Library API for fetching metadata.
  - Update `book_lookup_node` function to merge metadata from both sources.

* **tests/test_book_lookup_node.py**
  - Add tests for `get_book_metadata_from_openlibrary` function.
  - Add tests for the updated `book_lookup_node` function to ensure it fetches and merges metadata correctly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PatrickKalkman/shelf-genius/pull/7?shareId=b4c4374f-487d-4d7d-a5ee-9e5b06be1696).